### PR TITLE
156800 1/2 Fixed java.lang.IncompatibleClassChangeError

### DIFF
--- a/plugin/info.xml
+++ b/plugin/info.xml
@@ -130,6 +130,9 @@
 	  <release-note plugin-version="4">
         GitHub Community Release
 	  </release-note>
+	  <release-note plugin-version="4">
+		  <p>Fixed java.lang.IncompatibleClassChangeError</p>
+	  </release-note>
     
   </release-notes>
 </pluginInfo>

--- a/plugin/info.xml
+++ b/plugin/info.xml
@@ -130,7 +130,7 @@
 	  <release-note plugin-version="4">
         GitHub Community Release
 	  </release-note>
-	  <release-note plugin-version="4">
+	  <release-note plugin-version="5">
 		  <p>Fixed java.lang.IncompatibleClassChangeError</p>
 	  </release-note>
     

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.urbancode.com/PluginXMLSchema_v1" xmlns:server="http://www.urbancode.com/PluginServerXMLSchema_v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <header>
-    <identifier id="UCD_Siebel_JDB_DS" name="Siebel 8.x UCD plugin" version="4"/>
+    <identifier id="UCD_Siebel_JDB_DS" name="Siebel 8.x UCD plugin" version="5"/>
     <description>Siebel 8.x UCD plugin</description>
     <tag>Application Server/Siebel 8.x</tag>
     <server:plugin-type>Automation</server:plugin-type>

--- a/plugin/upgrade.xml
+++ b/plugin/upgrade.xml
@@ -3,4 +3,5 @@
   <!-- The purpose of plugin.xml is to provide upgrade paths when the plugin version is changed.
        If the upgrade paths are specified correctly, users will be upgraded to the new version 
        without interruption. -->
+  <migrate to-version="5"/>
 </plugin-upgrade>

--- a/src/main/scripts/StartStop.groovy
+++ b/src/main/scripts/StartStop.groovy
@@ -1,12 +1,11 @@
 /**
- * © Copyright IBM Corporation 2015, 2016.
+ * Â© Copyright IBM Corporation 2015, 2016.
  * This is licensed under the following license.
  * The Eclipse Public 1.0 License (http://www.eclipse.org/legal/epl-v10.html)
  * U.S. Government Users Restricted Rights:  Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
  */
 import com.urbancode.air.AirPluginTool;
 import com.urbancode.air.CommandHelper;
-import com.urbancode.air.ExitCodeException;
 import java.util.Date;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -251,7 +250,7 @@ try
 {
 	ch.runCommand("Applying Action on Server", scriptArgs);
 }
-catch (ExitCodeException e)
+catch (Exception e)
 {
 	cleanUp.call()
 	println(myName+": ["+e.getMessage()+"]");


### PR DESCRIPTION
Our com.urbancode.air.ExitCodeException class in the project air/plugins is throwing a java.lang.IncompatibleClassChangeError on java 7.  com.urbancode.air.ExitCodeException extends Exception and the binaries used in this plug-in where compiled using Java 6. In java 7 the Exception class got an extra constructor. Groovy checks things such as the amount on constructors and runtime hence the error.

We need to rewirte the exception in Java. There is no good work around except to not use it.

Fixed java.lang.IncompatibleClassChangeError
